### PR TITLE
Add github actions workflows for automatic testing&releases

### DIFF
--- a/.github/workflows/maven-compile.yml
+++ b/.github/workflows/maven-compile.yml
@@ -1,0 +1,28 @@
+# This workflow will build a package using Maven and then publish it when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Compile
+
+on:
+  pull_request:
+    branches: [ master, main ]
+  push:
+    branches: [ master, main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,32 @@
+# This workflow will build a package using Maven and then publish it when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        cache: 'maven'
+        server-id: gtnh
+        server-username: ${{ secrets.MAVEN_USERNAME }}
+        server-password: ${{ secrets.MAVEN_PASSWORD }}
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -8,14 +7,14 @@
         <version>9</version>
     </parent>
 
-    <groupId>net.md-5</groupId>
+    <groupId>com.github.GTNewHorizons</groupId>
     <artifactId>SpecialSource</artifactId>
-    <version>1.11.1-SNAPSHOT</version>
+    <version>1.7.5</version>
     <packaging>jar</packaging>
 
     <name>SpecialSource</name>
     <description>A jar compare and renaming engine designed for comparing and remapping 2 jars of differnent obfuscation mappings. Can also be useful for reobfuscation.</description>
-    <url>https://github.com/md-5/SpecialSource</url>
+    <url>https://github.com/GTNewHorizons/SpecialSource</url>
     <inceptionYear>2012</inceptionYear>
     <licenses>
         <license>
@@ -26,9 +25,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:md-5/SpecialSource.git</connection>
-        <developerConnection>scm:git:git@github.com:md-5/SpecialSource.git</developerConnection>
-        <url>git@github.com:md-5/SpecialSource.git</url>
+        <connection>scm:git:git@github.com:GTNewHorizons/SpecialSource.git</connection>
+        <developerConnection>scm:git:git@github.com:GTNewHorizons/SpecialSource.git</developerConnection>
+        <url>git@github.com:GTNewHorizons/SpecialSource.git</url>
     </scm>
     <issueManagement>
         <system>GitHub</system>
@@ -126,6 +125,20 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>io.github.zlika</groupId>
                 <artifactId>reproducible-build-maven-plugin</artifactId>
                 <version>0.15</version>
@@ -139,4 +152,12 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>gtnh</id>
+            <name>GTNH Maven</name>
+            <url>http://jenkins.usrv.eu:8081/nexus/content/repositories/releases</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Also fix up some of the pom.xml metadata.

This is a simple java library rather than a minecraft mod, therefore it doesn't use the shared buildscript as there's no minecraft dependency - I think keeping it using pom.xml should be fine.